### PR TITLE
Add CI workflow with style and static analysis checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,29 @@ on:
   pull_request:
 
 jobs:
-  build:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+      - run: composer install --prefer-dist --no-progress
+      - run: vendor/bin/phpcs
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+      - run: composer install --prefer-dist --no-progress
+      - run: vendor/bin/psalm
+
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +37,4 @@ jobs:
           coverage: xdebug
           tools: composer:v2
       - run: composer install --prefer-dist --no-progress
-      - run: vendor/bin/phpcs
-      - run: vendor/bin/psalm
       - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,6 @@ jobs:
           tools: composer:v2
       - run: composer install --prefer-dist --no-progress
       - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=coverage.xml
+      - name: Enforce 100% coverage
+        run: |
+          php -r '$xml=new SimpleXMLElement(file_get_contents("coverage.xml")); $m=$xml->project->metrics; $elements=(int)$m["elements"]; $covered=(int)$m["coveredelements"]; $pct=$elements?($covered/$elements*100):0; $msg=sprintf("Total coverage: %.2f%%", $pct); echo $msg . PHP_EOL; file_put_contents(getenv("GITHUB_STEP_SUMMARY"), $msg . PHP_EOL); if ($covered < $elements) { fwrite(STDERR, "Coverage must be 100%\n"); exit(1); }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: xdebug
+          tools: composer:v2
+      - run: composer install --prefer-dist --no-progress
+      - run: vendor/bin/phpcs
+      - run: vendor/bin/psalm
+      - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "mockery/mockery": "^1.5"
+        "mockery/mockery": "^1.5",
+        "squizlabs/php_codesniffer": "^3",
+        "vimeo/psalm": "^5"
     },
     "autoload": {
         "psr-4": {"CarrionGrow\\FormulaParser\\": "src/"},

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Project Rules">
+    <rule ref="PSR12"/>
+    <file>src</file>
+    <file>test</file>
+</ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>test</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<psalm xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://getpsalm.org/schema/config"
+       errorLevel="1"
+       findUnusedCode="true">
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running tests with coverage, PSR-12 coding standards, and Psalm
- add phpcs and psalm configuration
- include development dependencies for code style and static analysis

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/psalm` *(fails: No such file or directory)*
- `vendor/bin/phpunit --coverage-clover=coverage.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a037aa1f90832a95d91d63cf285e57